### PR TITLE
[VOLO-001 | Feature] Lighten Comment Color

### DIFF
--- a/themes/gotham.json
+++ b/themes/gotham.json
@@ -89,7 +89,7 @@
 			"name": "Comment",
 			"scope": "comment",
 			"settings": {
-				"foreground": "#093748"
+				"foreground": "#225b70"
 			}
 		},
 		{


### PR DESCRIPTION
The original theme was really solid, but there wasn't enough contrast between the background and comments for my taste. Lightened the color of comments so they stand out more.